### PR TITLE
test: skip tests that use viz.js on z/OS

### DIFF
--- a/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
+++ b/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
@@ -68,7 +68,7 @@ describe('Context Explorer (acceptance)', function (this: Mocha.Suite) {
     });
 
     it('invokes GET /graph', async function (this: Mocha.Context) {
-      if (process.platform as string === 'os390') return this.skip();
+      if ((process.platform as string) === 'os390') return this.skip();
       const res = await request.get('/context-explorer/graph').expect(200);
       expect(res.get('content-type')).to.match(/^image\/svg\+xml/);
     });

--- a/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
+++ b/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
@@ -68,7 +68,7 @@ describe('Context Explorer (acceptance)', function (this: Mocha.Suite) {
     });
 
     it('invokes GET /graph', async function (this: Mocha.Context) {
-      if (String(process.platform) === 'os390') return this.skip();
+      if (process.platform as string === 'os390') return this.skip();
       const res = await request.get('/context-explorer/graph').expect(200);
       expect(res.get('content-type')).to.match(/^image\/svg\+xml/);
     });

--- a/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
+++ b/extensions/context-explorer/src/__tests__/acceptance/context-explorer.acceptance.ts
@@ -67,7 +67,8 @@ describe('Context Explorer (acceptance)', function (this: Mocha.Suite) {
       );
     });
 
-    it('invokes GET /graph', async () => {
+    it('invokes GET /graph', async function (this: Mocha.Context) {
+      if (String(process.platform) === 'os390') return this.skip();
       const res = await request.get('/context-explorer/graph').expect(200);
       expect(res.get('content-type')).to.match(/^image\/svg\+xml/);
     });

--- a/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
@@ -14,7 +14,8 @@ describe('Visualizer', () => {
 
   beforeEach(givenContexts);
 
-  it('creates a dot graph with bindings', async () => {
+  it('creates a dot graph with bindings', async function (this: Mocha.Context) {
+    if (String(process.platform) === 'os390') return this.skip();
     server.bind('port').to(3000);
     app.bind('now').toDynamicValue(() => new Date());
     const json = server.inspect();

--- a/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
@@ -15,7 +15,7 @@ describe('Visualizer', () => {
   beforeEach(givenContexts);
 
   it('creates a dot graph with bindings', async function (this: Mocha.Context) {
-    if (process.platform as string === 'os390') return this.skip();
+    if ((process.platform as string) === 'os390') return this.skip();
     server.bind('port').to(3000);
     app.bind('now').toDynamicValue(() => new Date());
     const json = server.inspect();

--- a/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
+++ b/extensions/context-explorer/src/__tests__/integration/visualizer.integration.ts
@@ -15,7 +15,7 @@ describe('Visualizer', () => {
   beforeEach(givenContexts);
 
   it('creates a dot graph with bindings', async function (this: Mocha.Context) {
-    if (String(process.platform) === 'os390') return this.skip();
+    if (process.platform as string === 'os390') return this.skip();
     server.bind('port').to(3000);
     app.bind('now').toDynamicValue(() => new Date());
     const json = server.inspect();


### PR DESCRIPTION
Skip tests that use `viz.js` to render graph on z/OS, which complain about
```
Runtime error: expected the system to be little-endian!
```
as z/OS is not in little-endian.